### PR TITLE
v1.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,30 +58,6 @@ tasks.named("build") {
     dependsOn("shadowJar", "copyContents")
 }
 
-// --- Publishing configuration for Maven (GitHub Packages with ShadowJar) ---
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            artifact(tasks.named<ShadowJar>("shadowJar").get()) {
-                classifier = null
-            }
-            groupId = project.group.toString()
-            artifactId = "lyttleadmin"
-            version = versionString
-        }
-    }
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Lyttle-Development/LyttleAdmin")
-            credentials {
-                username = project.findProperty("GPR_USER") as String? ?: System.getenv("GPR_USER")
-                password = project.findProperty("GPR_API_KEY") as String? ?: System.getenv("GPR_API_KEY")
-            }
-        }
-    }
-}
-
 // --- Encoding setup for Java and Javadoc ---
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
@@ -151,6 +127,30 @@ val versionString: String = when (envChannel) {
 tasks.named<ProcessResources>("processResources") {
     filesMatching("plugin.yml") {
         expand("projectVersion" to versionString)
+    }
+}
+
+// --- Publishing configuration for Maven (GitHub Packages with ShadowJar) ---
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            artifact(tasks.named<ShadowJar>("shadowJar").get()) {
+                classifier = null
+            }
+            groupId = project.group.toString()
+            artifactId = "lyttleadmin"
+            version = versionString
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/Lyttle-Development/LyttleAdmin")
+            credentials {
+                username = System.getenv("GPR_USER") ?: project.findProperty("gpr.user") as String?
+                password = System.getenv("GPR_API_KEY") ?: project.findProperty("gpr.key") as String?
+            }
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
             }
             groupId = project.group.toString()
             artifactId = "lyttleadmin"
-            version = (property("pluginVersion") as String)
+            version = versionString
         }
     }
     repositories {
@@ -144,7 +144,7 @@ val runNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 val versionString: String = when (envChannel) {
     "Release" -> version.toString()
     "Snapshot" -> if (runNumber != null) "${version}-SNAPSHOT+$runNumber" else "${version}-SNAPSHOT"
-    else -> if (runNumber != null) "${version}-${envChannel.uppercase()}+$runNumber" else "$version-${envChannel.uppercase()}"
+    else -> if (runNumber != null) "${version}-${envChannel.uppercase()}.$runNumber" else "$version-${envChannel.uppercase()}"
 }
 
 // --- Version expansion in plugin.yml ---


### PR DESCRIPTION
This pull request updates the workflows for publishing packages, improves version handling, and refines command message functionality. The changes primarily focus on enhancing automation and user experience.

### Workflow Updates
* Renamed the workflow to "Release & Publish Packages (Alpha Branch)" and added detailed comments for each step. Integrated publishing to GitHub Packages, Hangar, and Modrinth platforms.
* Renamed the workflow to "Release & Publish Packages (Beta Branch)" with similar updates as the Alpha workflow, including publishing to multiple platforms.
* Renamed the workflow to "Release & Publish Packages (Beta Branch)" and changed the branch trigger from `main` to `beta`. Added publishing steps for GitHub Packages, Hangar, and Modrinth.

### Version Updates
* Updated the plugin version from `1.2.1` to `1.2.2` and incremented the `paperVersion` from `1.21.5` to `1.21.6`.

### Command Improvements
* Enhanced the `/lyttleadmin` command to dynamically fetch the plugin version using `plugin.getDescription().getVersion` and send messages using the `plugin.message.sendMessageRaw` method.

### Miscellaneous
* Removed the `permission` field from the `staff` command configuration.